### PR TITLE
Feature custom tag visited

### DIFF
--- a/modules/svg/tag_classes.js
+++ b/modules/svg/tag_classes.js
@@ -169,6 +169,8 @@ export function svgTagClasses() {
             classes.push('tag-visited');
         } else if (visited === 'no') {
             classes.push('tag-unvisited');
+        } else if (visited) {
+            classes.push('tag-visited-unknown');
         }
 
         // ensure that classes for tags keys/values with special characters like spaces

--- a/modules/svg/tag_classes.js
+++ b/modules/svg/tag_classes.js
@@ -163,6 +163,13 @@ export function svgTagClasses() {
             classes.push('tag-custom');
             classes.push('tag-custom-' + custom_tag);
         }
+        // Look for custom:visited tag
+        var visited = t['custom:visited'];
+        if (visited === 'yes') {
+            classes.push('tag-visited');
+        } else if (visited === 'no') {
+            classes.push('tag-unvisited');
+        }
 
         // ensure that classes for tags keys/values with special characters like spaces
         // are not added to the DOM, because it can cause bizarre issues (#9448)


### PR DESCRIPTION
This pull request adds support for custom "visited" tags in the SVG tag class generation logic. The main change is the handling of the `custom:visited` property, which now results in different CSS classes based on its value.

Enhancement to tag class generation:

* [`modules/svg/tag_classes.js`](diffhunk://#diff-098961f5e35e4e86cb55139455b2708c6ea7dcfd5b3986c25ad995274778ed96R166-R174): Added logic to check for the `custom:visited` property and append `tag-visited`, `tag-unvisited`, or `tag-visited-unknown` CSS classes based on its value.